### PR TITLE
region override in combination with profile works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## 0.1.5
+
+FIXES:
+* region override in combination with profile works
+
 ## 0.1.4
 
 FIXES:

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -469,14 +469,14 @@ func (p *FastSSMProvider) Configure(ctx context.Context, req provider.ConfigureR
 		options = append(options, config.WithRetryMode(mode), config.WithRetryMaxAttempts(25))
 	}
 
-	// Region
-	if !data.Region.IsNull() {
-		options = append(options, config.WithDefaultRegion(data.Region.ValueString()))
-	}
-
 	// AWS Profile
 	if !data.Profile.IsNull() {
 		options = append(options, config.WithSharedConfigProfile(data.Profile.ValueString()))
+	}
+
+	// Region
+	if !data.Region.IsNull() {
+		options = append(options, config.WithDefaultRegion(data.Region.ValueString()))
 	}
 
 	// Static credentials


### PR DESCRIPTION
Ensure region override works even if profile is the authentication method.