### PR TITLE
use withRegion() to supersede any other region configuration if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## 0.1.6
+
+FIXES:
+* correctly wrap retry errors, so they are recognised as such, instead of generic client error
+* region override must use WithRegion() function call so it superseeds any others, including WithDefaultRegion()
+
 ## 0.1.5
 
 FIXES:

--- a/internal/provider/parameter_data_source.go
+++ b/internal/provider/parameter_data_source.go
@@ -163,11 +163,11 @@ func (d *ParameterDataSource) Read(ctx context.Context, req datasource.ReadReque
 			// Check if the error is retryable (e.g., rate limiting, network issues)
 			if isRetryableError(ctx, erri) {
 				// Return with retryable error, specifying how long to wait before the next retry
-				return retry.RetryableError(fmt.Errorf("temporary failure: %v, retrying...", erri))
+				return retry.RetryableError(fmt.Errorf("temporary failure: %w, retrying...", erri))
 			}
 
 			// If it's a permanent error, stop retrying
-			return retry.NonRetryableError(fmt.Errorf("permanent failure: %v", erri))
+			return retry.NonRetryableError(fmt.Errorf("permanent failure: %w", erri))
 		}
 
 		// If success, return nil (no retry)
@@ -182,7 +182,7 @@ func (d *ParameterDataSource) Read(ctx context.Context, req datasource.ReadReque
 	}
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read example, got error: %s", err))
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read parameter, got error: %v", err))
 		return
 	}
 

--- a/internal/provider/parameter_resource.go
+++ b/internal/provider/parameter_resource.go
@@ -248,11 +248,11 @@ func (r *ParameterResource) Create(ctx context.Context, req resource.CreateReque
 			// Check if the error is retryable (e.g., rate limiting, network issues)
 			if isRetryableError(ctx, erri) {
 				// Return with retryable error, specifying how long to wait before the next retry
-				return retry.RetryableError(fmt.Errorf("temporary failure: %v, retrying...", erri))
+				return retry.RetryableError(fmt.Errorf("temporary failure: %w, retrying...", erri))
 			}
 
 			// If it's a permanent error, stop retrying
-			return retry.NonRetryableError(fmt.Errorf("permanent failure: %v", erri))
+			return retry.NonRetryableError(fmt.Errorf("permanent failure: %w", erri))
 		}
 
 		// If success, return nil (no retry)
@@ -313,11 +313,11 @@ func (r *ParameterResource) Read(ctx context.Context, req resource.ReadRequest, 
 			// Check if the error is retryable (e.g., rate limiting, network issues)
 			if isRetryableError(ctx, erri) {
 				// Return with retryable error, specifying how long to wait before the next retry
-				return retry.RetryableError(fmt.Errorf("temporary failure: %v, retrying...", erri))
+				return retry.RetryableError(fmt.Errorf("temporary failure: %w, retrying...", erri))
 			}
 
 			// If it's a permanent error, stop retrying
-			return retry.NonRetryableError(fmt.Errorf("permanent failure: %v", erri))
+			return retry.NonRetryableError(fmt.Errorf("permanent failure: %w", erri))
 		}
 
 		// If success, return nil (no retry)
@@ -362,11 +362,11 @@ func (r *ParameterResource) Read(ctx context.Context, req resource.ReadRequest, 
 					// Check if the error is retryable (e.g., rate limiting, network issues)
 					if isRetryableError(ctx, erri) {
 						// Return with retryable error, specifying how long to wait before the next retry
-						return retry.RetryableError(fmt.Errorf("temporary failure: %v, retrying...", erri))
+						return retry.RetryableError(fmt.Errorf("temporary failure: %w, retrying...", erri))
 					}
 
 					// If it's a permanent error, stop retrying
-					return retry.NonRetryableError(fmt.Errorf("permanent failure: %v", erri))
+					return retry.NonRetryableError(fmt.Errorf("permanent failure: %w", erri))
 				}
 
 				// If success, return nil (no retry)
@@ -460,11 +460,11 @@ func (r *ParameterResource) Update(ctx context.Context, req resource.UpdateReque
 			// Check if the error is retryable (e.g., rate limiting, network issues)
 			if isRetryableError(ctx, erri) {
 				// Return with retryable error, specifying how long to wait before the next retry
-				return retry.RetryableError(fmt.Errorf("temporary failure: %v, retrying...", erri))
+				return retry.RetryableError(fmt.Errorf("temporary failure: %w, retrying...", erri))
 			}
 
 			// If it's a permanent error, stop retrying
-			return retry.NonRetryableError(fmt.Errorf("permanent failure: %v", erri))
+			return retry.NonRetryableError(fmt.Errorf("permanent failure: %w", erri))
 		}
 
 		// If success, return nil (no retry)
@@ -490,11 +490,11 @@ func (r *ParameterResource) Update(ctx context.Context, req resource.UpdateReque
 			// Check if the error is retryable (e.g., rate limiting, network issues)
 			if isRetryableError(ctx, erri) {
 				// Return with retryable error, specifying how long to wait before the next retry
-				return retry.RetryableError(fmt.Errorf("temporary failure: %v, retrying...", erri))
+				return retry.RetryableError(fmt.Errorf("temporary failure: %w, retrying...", erri))
 			}
 
 			// If it's a permanent error, stop retrying
-			return retry.NonRetryableError(fmt.Errorf("permanent failure: %v", erri))
+			return retry.NonRetryableError(fmt.Errorf("permanent failure: %w", erri))
 		}
 
 		// If success, return nil (no retry)
@@ -536,11 +536,11 @@ func (r *ParameterResource) Delete(ctx context.Context, req resource.DeleteReque
 			// Check if the error is retryable (e.g., rate limiting, network issues)
 			if isRetryableError(ctx, erri) {
 				// Return with retryable error, specifying how long to wait before the next retry
-				return retry.RetryableError(fmt.Errorf("temporary failure: %v, retrying...", erri))
+				return retry.RetryableError(fmt.Errorf("temporary failure: %w, retrying...", erri))
 			}
 
 			// If it's a permanent error, stop retrying
-			return retry.NonRetryableError(fmt.Errorf("permanent failure: %v", erri))
+			return retry.NonRetryableError(fmt.Errorf("permanent failure: %w", erri))
 		}
 
 		// If success, return nil (no retry)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -476,7 +476,7 @@ func (p *FastSSMProvider) Configure(ctx context.Context, req provider.ConfigureR
 
 	// Region
 	if !data.Region.IsNull() {
-		options = append(options, config.WithDefaultRegion(data.Region.ValueString()))
+		options = append(options, config.WithRegion(data.Region.ValueString()))
 	}
 
 	// Static credentials


### PR DESCRIPTION
Region override needs a different function call to ensure it works.
Error messages are also now improved. Now:
```
│ Error: parameter not found
│ 
│   with data.fastssm_parameter.this["EXAMPLE"],
│   on main.tf line 18, in data "fastssm_parameter" "this":
│   18: data "fastssm_parameter" "this" {
│ 
│ SSM Parameter "/path/to/my/example" not found, removing from state
╵
```

Before:

```
│ Error: Client Error
│ 
│   with data.fastssm_parameter.this["EXAMPLE"],
│   on main.tf line 18, in data "fastssm_parameter" "this":
│   18: data "fastssm_parameter" "this" {
│ 
│ Unable to read example, got error: permanent failure: couldn't find resource
```